### PR TITLE
feat: Add SSL Policiy spec to the GCP LB Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kpt-packages
-A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints 
+A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints
 
 ## What is a Kpt Package?
 
@@ -7,7 +7,20 @@ A Kpt package is a collection of Kubernetes resources that are managed together 
 
 The packages in this repo can be used alone or as part of a larger application. They can be used to create a new application, or to add functionality to an existing application.  To learn more about packages, see the [Kpt Packages Overview](https://kpt.dev/book/02-concepts/01-packages).
 
-You can install a package by running `kpt pkg get https://github.com/broadinstitute/kpt-packages/grafana  --for-deployment` 
+You can install a package by running `kpt pkg get https://github.com/broadinstitute/kpt-packages/grafana  --for-deployment`
 
-You can then update the package inputs to set the package parameters.  Running `kpt fn render grafana` will render the package with the updated inputs.  
+You can then update the package inputs to set the package parameters.  Running `kpt fn render grafana` will render the package with the updated inputs.
 
+## How to use a Kpt Package
+
+To use a package, you can run `kpt pkg get <package-path> --for-deployment`.  This will download the package to your local machine and set it up for deployment.  You can then run `kpt fn render <package-name>` to render the package with the default inputs.
+
+example:
+
+```Shell
+kpt pkg get https://github.com/broadinstitute/kpt-packages/gcp-load-balancer/@v0
+```
+
+## Update a package to a new version
+
+To update an installed package to a new version, run `kpt pkg update <package-path>`.  This will update the package to the version in the upstream repo.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# kpt-packages
+A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints 
+
+## What is a Kpt Package?
+
+A Kpt package is a collection of Kubernetes resources that are managed together as a unit. A package can be a single Kubernetes resource, or a collection of resources such as a Deployment, Service, and ConfigMap. A package can also be a collection of other packages.
+
+The packages in this repo can be used alone or as part of a larger application. They can be used to create a new application, or to add functionality to an existing application.  To learn more about packages, see the [Kpt Packages Overview](https://kpt.dev/book/02-concepts/01-packages).
+
+You can install a package by running `kpt pkg get https://github.com/broadinstitute/kpt-packages/grafana  --for-deployment` 
+
+You can then update the package inputs to set the package parameters.  Running `kpt fn render grafana` will render the package with the updated inputs.  
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # kpt-packages
-A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints 
+A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints
 
 ## What is a Kpt Package?
 
@@ -7,7 +7,20 @@ A Kpt package is a collection of Kubernetes resources that are managed together 
 
 The packages in this repo can be used alone or as part of a larger application. They can be used to create a new application, or to add functionality to an existing application.  To learn more about packages, see the [Kpt Packages Overview](https://kpt.dev/book/02-concepts/01-packages).
 
-You can install a package by running `kpt pkg get https://github.com/broadinstitute/kpt-packages/grafana  --for-deployment` 
+You can install a package by running `kpt pkg get https://github.com/broadinstitute/kpt-packages/grafana  --for-deployment`
 
-You can then update the package inputs to set the package parameters.  Running `kpt fn render grafana` will render the package with the updated inputs.  
+You can then update the package inputs to set the package parameters.  Running `kpt fn render grafana` will render the package with the updated inputs.
 
+## How to use a Kpt Package
+
+To use a package, you can run `kpt pkg get <package-path> --for-deployment`.  This will download the package to your local machine and set it up for deployment.  You can then run `kpt fn render <package-name>` to render the package with the default inputs.
+
+example:
+
+```Shell
+kpt pkg get https://github.com/broadinstitute/kpt-packages/gcp-load-balancer/@v0
+```
+
+## Update a package to a new version
+
+To update an installed package to a new version, run `kpt pkg update <package-path>`.  This will update the package to the version in the upstream repo.

--- a/gcp-load-balancer/Kptfile
+++ b/gcp-load-balancer/Kptfile
@@ -25,6 +25,7 @@ pipeline:
         name: gcp-load-balancer
         project-id: "monitoring-scope-project-id"
         cert-name: host.example.com
+        sslPolicy: "gcp-load-balancer-ssl-policy"
   validators:
     - image: gcr.io/kpt-fn/kubeval:v0.3
       configMap:

--- a/gcp-load-balancer/frontendconfig.yaml
+++ b/gcp-load-balancer/frontendconfig.yaml
@@ -7,6 +7,7 @@ metadata:
     backstage.io/kubernetes-id: backstage-component-id
     app: gcp-load-balancer # kpt-set: ${name}
 spec:
+  sslPolicy: gke-ingress-ssl-policy # kpt-set: ${sslPolicy}
   redirectToHttps:
     enabled: true
     responseCodeName: MOVED_PERMANENTLY_DEFAULT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+---
+site_name: 'A Catalog of [Kpt](https://kpt.dev/) Packages and Blueprints'
+
+nav:
+  - Home: index.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
This allows users to define GCP SSL policies to be used by the GCP Load balancers.  The Policies must be created outside of the package via Terraform or Config Connector. 

Also a number of doc updates. 